### PR TITLE
Use a different schema for the read model

### DIFF
--- a/src/Examples/Shopping.ReadModel/appsettings.Development.json
+++ b/src/Examples/Shopping.ReadModel/appsettings.Development.json
@@ -13,6 +13,6 @@
     "ConnectionString": "Server=shopping.db;Port=5432;Database=shopping;User Id=postgres;Password=postgres;"
   },
   "ConnectionStrings": {
-    "Default": "Server=shopping.db;Port=5432;Database=shopping;User Id=postgres;Password=postgres;"
+    "Default": "Server=shopping.db;Port=5432;Database=shopping-read;User Id=postgres;Password=postgres;"
   }
 }


### PR DESCRIPTION
We're forcing the read model schema to be recreated on every startup.

In a future version we want to give more control to the consumer on how to start up a read model, tools like bookmarking. Until then this fixes a bug where we we're deleting the "write side" schema.