### PR TITLE
Don't drop the entire DB

### DIFF
--- a/src/DomainBlocks.Projections.EntityFramework/EntityFrameworkProjectionContext.cs
+++ b/src/DomainBlocks.Projections.EntityFramework/EntityFrameworkProjectionContext.cs
@@ -24,7 +24,7 @@ namespace DomainBlocks.Projections.EntityFramework
             try
             {
                 var database = _dbContext.Database;
-                await database.EnsureDeletedAsync().ConfigureAwait(false);
+                // await database.EnsureDeletedAsync().ConfigureAwait(false);
                 await database.EnsureCreatedAsync().ConfigureAwait(false);
 
                 _isProcessingLiveEvents = false;


### PR DESCRIPTION
Workaround for avoiding the readmodel destroying the entire database if it's shared with the write model