### PR TITLE
Small fixes for some issues discovered during testing

### DIFF
--- a/src/DomainBlocks.Common/Logger.cs
+++ b/src/DomainBlocks.Common/Logger.cs
@@ -20,7 +20,9 @@ namespace DomainBlocks.Common
         /// This should be done once on start-up of your application and not changed again./>
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if user tries to change the <see cref="Microsoft.Extensions.Logging.ILoggerFactory" /> once set.</exception>
-        public static void SetLoggerFactory(ILoggerFactory loggerFactory)
+        public static void SetLoggerFactory(
+            ILoggerFactory loggerFactory,
+            bool throwOnSettingLoggerFactoryIfAlreadySet = true)
         {
             if (Interlocked.CompareExchange(ref _userLoggerFactorySet, 1, 0) == 0)
             {
@@ -28,7 +30,8 @@ namespace DomainBlocks.Common
             }
             else
             {
-                throw new InvalidOperationException("LoggerFactory has already been set. Cannot set it again.");
+                if (throwOnSettingLoggerFactoryIfAlreadySet)
+                    throw new InvalidOperationException("LoggerFactory has already been set. Cannot set it again.");
             }
         }
 

--- a/src/DomainBlocks.SqlStreamStore.Common.AspNetCore/SqlStreamStoreServiceConfigurationExtensions.cs
+++ b/src/DomainBlocks.SqlStreamStore.Common.AspNetCore/SqlStreamStoreServiceConfigurationExtensions.cs
@@ -29,14 +29,20 @@ namespace DomainBlocks.SqlStreamStore.Common.AspNetCore
                             var settings = new PostgresStreamStoreSettings(options.Value.ConnectionString);
                             _sqlStreamStore = new PostgresStreamStore(settings);
                             _sqlStreamStore.CreateSchemaIfNotExists().Wait();
+                            _sqlStreamStore.OnDispose += OnPostgresStreamStoreDisposed;
                         }
                     }
                 }
-
+                
                 return _sqlStreamStore;
             });
 
             return services;
+        }
+
+        private static void OnPostgresStreamStoreDisposed()
+        {
+            _sqlStreamStore = null;
         }
     }
 }


### PR DESCRIPTION
When disposing the SqlStreamstore connection, we must no longer reference it

When calling SetLoggerFactory multiple times, add the option to not have an exception