### PR TITLE
Add WithProjections overload which exposes IServiceProvider

### DIFF
--- a/src/DomainBlocks.Projections.AspNetCore/ReadModelServiceCollectionExtensions.cs
+++ b/src/DomainBlocks.Projections.AspNetCore/ReadModelServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 
 namespace DomainBlocks.Projections.AspNetCore
 {

--- a/src/DomainBlocks.Projections.EntityFramework.AspNetCore/EntityFrameworkProjectionRegistrationBuilder.cs
+++ b/src/DomainBlocks.Projections.EntityFramework.AspNetCore/EntityFrameworkProjectionRegistrationBuilder.cs
@@ -18,6 +18,16 @@ namespace DomainBlocks.Projections.EntityFramework.AspNetCore
             };
         }
 
+        public void WithProjections(Action<ProjectionRegistryBuilder, TDbContext, IServiceProvider> onRegisteringProjections)
+        {
+            _onRegisteringProjections = (provider, builder) =>
+            {
+                var dispatcherScope = provider.CreateScope();
+                var dbContext = dispatcherScope.ServiceProvider.GetRequiredService<TDbContext>();
+                onRegisteringProjections(builder, dbContext, dispatcherScope.ServiceProvider);
+            };
+        }
+
         public Action<IServiceProvider, ProjectionRegistryBuilder> Build()
         {
             return (provider, builder) => _onRegisteringProjections(provider, builder);

--- a/src/Examples/Shopping.ReadModel/Startup.cs
+++ b/src/Examples/Shopping.ReadModel/Startup.cs
@@ -1,5 +1,3 @@
-using System;
-using DomainBlocks.Projections;
 using DomainBlocks.Projections.AspNetCore;
 using DomainBlocks.Projections.EntityFramework.AspNetCore;
 using DomainBlocks.Projections.SqlStreamStore;
@@ -12,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Shopping.ReadModel.Db;
-using SqlStreamStore.Streams;
 
 namespace Shopping.ReadModel
 {


### PR DESCRIPTION
This is a temporary solution to allow for dependency injection within projections.

The longer term approach is to tidy up the fluent registrations to have a clean and common approach across all storage implementations.