### PR TITLE
fix: fix paging when reading events from SqlStreamStoreEventsRepository.

### DIFF
--- a/src/DomainBlocks.Persistence.SqlStreamStore.Tests/DomainBlocks.Persistence.SqlStreamStore.Tests.csproj
+++ b/src/DomainBlocks.Persistence.SqlStreamStore.Tests/DomainBlocks.Persistence.SqlStreamStore.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DomainBlocks.Persistence.SqlStreamStore\DomainBlocks.Persistence.SqlStreamStore.csproj" />
+      <ProjectReference Include="..\DomainBlocks.Serialization.Json\DomainBlocks.Serialization.Json.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/DomainBlocks.Persistence.SqlStreamStore.Tests/SqlStreamStoreEventsRepositoryTests.cs
+++ b/src/DomainBlocks.Persistence.SqlStreamStore.Tests/SqlStreamStoreEventsRepositoryTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DomainBlocks.Core;
+using DomainBlocks.Serialization.Json;
+using NUnit.Framework;
+using SqlStreamStore;
+
+namespace DomainBlocks.Persistence.SqlStreamStore.Tests;
+
+[TestFixture]
+public class SqlStreamStoreEventsRepositoryTests
+{
+    [Test]
+    public async Task RoundTripTest()
+    {
+        using var streamStore = new InMemoryStreamStore();
+        var eventNameMap = new EventNameMap();
+        eventNameMap.Add(nameof(EventSaved), typeof(EventSaved));
+        var eventSerializer = new JsonStringEventSerializer(eventNameMap);
+
+        const int readPageSize = 2;
+        var eventsRepository = new SqlStreamStoreEventsRepository(streamStore, eventSerializer, readPageSize);
+
+        var events = Enumerable
+            .Range(0, 10)
+            .Select(i => new EventSaved($"Value {i}"))
+            .ToList();
+
+        var version = await eventsRepository.SaveEventsAsync("test-stream", -1, events);
+        var loadedEvents = await eventsRepository.LoadEventsAsync("test-stream").ToListAsync();
+
+        Assert.That(version, Is.EqualTo(events.Count - 1));
+        Assert.That(loadedEvents, Is.EqualTo(events).Using(EventSavedEqualityComparer.Instance));
+    }
+
+    private class EventSaved
+    {
+        public EventSaved(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+    }
+    
+    private sealed class EventSavedEqualityComparer : IEqualityComparer<EventSaved>
+    {
+        public static readonly IEqualityComparer<EventSaved> Instance = new EventSavedEqualityComparer();
+            
+        public bool Equals(EventSaved x, EventSaved y)
+        {
+            if (ReferenceEquals(x, y)) return true;
+            if (ReferenceEquals(x, null)) return false;
+            if (ReferenceEquals(y, null)) return false;
+            if (x.GetType() != y.GetType()) return false;
+            return x.Value == y.Value;
+        }
+
+        public int GetHashCode(EventSaved obj)
+        {
+            // Not used in tests.
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/DomainBlocks.sln
+++ b/src/DomainBlocks.sln
@@ -93,6 +93,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DomainBlocks.SqlStreamStore
 EndProject
 Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "Shopping.DockerCompose", "Examples\Shopping.DockerCompose.dcproj", "{B494CB62-63D3-4514-8272-51F8AD6C61E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainBlocks.Persistence.SqlStreamStore.Tests", "DomainBlocks.Persistence.SqlStreamStore.Tests\DomainBlocks.Persistence.SqlStreamStore.Tests.csproj", "{394C95D2-C12A-4B8F-9F8F-9DEA439E5085}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -243,6 +245,10 @@ Global
 		{B494CB62-63D3-4514-8272-51F8AD6C61E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B494CB62-63D3-4514-8272-51F8AD6C61E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B494CB62-63D3-4514-8272-51F8AD6C61E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{394C95D2-C12A-4B8F-9F8F-9DEA439E5085}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{394C95D2-C12A-4B8F-9F8F-9DEA439E5085}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{394C95D2-C12A-4B8F-9F8F-9DEA439E5085}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{394C95D2-C12A-4B8F-9F8F-9DEA439E5085}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The previous logic around paging was broken.

Also: Decrease default page size to 600, which is more performant with postgres.

This should be merged into develop after #63.