### PR TITLE
Aggregate infrastructure config improvements.

### DIFF
--- a/src/DomainBlocks.EventPersistence.AspNetCore/AggregateServiceCollectionExtensions.cs
+++ b/src/DomainBlocks.EventPersistence.AspNetCore/AggregateServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using DomainBlocks.Core.Builders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using NewAggregateRepositoryOptionsBuilder = DomainBlocks.Persistence.New.AggregateRepositoryOptionsBuilder;
 
 namespace DomainBlocks.Persistence.AspNetCore;
 
@@ -44,6 +45,28 @@ public static class AggregateServiceCollectionExtensions
                 aggregateRepositoryOptions.EventsRepository,
                 aggregateRepositoryOptions.SnapshotRepository,
                 model);
+        });
+
+        return services;
+    }
+
+    // New approach
+    public static IServiceCollection AddAggregateRepository(
+        this IServiceCollection services,
+        Action<IServiceProvider, NewAggregateRepositoryOptionsBuilder> optionsAction,
+        Action<IServiceProvider, ModelBuilder> modelBuilderAction)
+    {
+        services.AddSingleton(sp =>
+        {
+            var optionsBuilder = new NewAggregateRepositoryOptionsBuilder();
+            optionsAction(sp, optionsBuilder);
+            var options = optionsBuilder.Options;
+
+            var modelBuilder = new ModelBuilder();
+            modelBuilderAction(sp, modelBuilder);
+            var model = modelBuilder.Build();
+
+            return options.CreateAggregateRepository(model);
         });
 
         return services;

--- a/src/DomainBlocks.Persistence.SqlStreamStore/DomainBlocks.Persistence.SqlStreamStore.csproj
+++ b/src/DomainBlocks.Persistence.SqlStreamStore/DomainBlocks.Persistence.SqlStreamStore.csproj
@@ -6,9 +6,11 @@
 
   <ItemGroup>
     <PackageReference Include="SqlStreamStore" Version="1.2.0-beta.8" />
+    <PackageReference Include="SqlStreamStore.Postgres" Version="1.2.0-beta.8" />
   </ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\DomainBlocks.Common\DomainBlocks.Common.csproj" />
 		<ProjectReference Include="..\DomainBlocks.Persistence\DomainBlocks.Persistence.csproj" />
+		<ProjectReference Include="..\DomainBlocks.Serialization.Json\DomainBlocks.Serialization.Json.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/DomainBlocks.Persistence.SqlStreamStore/New/AggregateRepositoryOptionsBuilderExtensions.cs
+++ b/src/DomainBlocks.Persistence.SqlStreamStore/New/AggregateRepositoryOptionsBuilderExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using DomainBlocks.Persistence.New;
+
+namespace DomainBlocks.Persistence.SqlStreamStore.New;
+
+public static class AggregateRepositoryOptionsBuilderExtensions
+{
+    public static AggregateRepositoryOptionsBuilder UseSqlStreamStore(
+        this AggregateRepositoryOptionsBuilder optionsBuilder,
+        Action<SqlStreamStoreOptionsBuilder> optionsAction)
+    {
+        if (optionsBuilder == null) throw new ArgumentNullException(nameof(optionsBuilder));
+        if (optionsAction == null) throw new ArgumentNullException(nameof(optionsAction));
+
+        var streamStoreOptionsBuilder = new SqlStreamStoreOptionsBuilder();
+        optionsAction(streamStoreOptionsBuilder);
+        var streamStoreOptions = streamStoreOptionsBuilder.Options;
+
+        ((IAggregateRepositoryOptionsBuilderInfrastructure)optionsBuilder)
+            .WithAggregateRepositoryFactory(model =>
+            {
+                var streamStore = streamStoreOptions.GetOrCreateStreamStore();
+                var eventSerializer = streamStoreOptions.GetOrCreateEventSerializer(model.EventNameMap);
+                var eventsRepository = new SqlStreamStoreEventsRepository(streamStore, eventSerializer);
+                var snapshotRepository = optionsBuilder.Options.CreateSnapshotRepository(model.EventNameMap);
+                return new AggregateRepository<string>(eventsRepository, snapshotRepository, model);
+            });
+
+        // This can be made configurable via the builder if we need to.
+        ((IAggregateRepositoryOptionsBuilderInfrastructure)optionsBuilder)
+            .WithSnapshotRepositoryFactory(eventNameMap =>
+            {
+                var streamStore = streamStoreOptions.GetOrCreateStreamStore();
+                var eventSerializer = streamStoreOptions.GetOrCreateEventSerializer(eventNameMap);
+                return new SqlStreamStoreSnapshotRepository(streamStore, eventSerializer);
+            });
+
+        return optionsBuilder;
+    }
+}

--- a/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptions.cs
+++ b/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptions.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using DomainBlocks.Core;
+using DomainBlocks.Serialization;
+using DomainBlocks.Serialization.Json;
+using SqlStreamStore;
+
+namespace DomainBlocks.Persistence.SqlStreamStore.New;
+
+public class SqlStreamStoreOptions
+{
+    private static readonly Func<IEventNameMap, IEventSerializer<string>> DefaultEventSerializerFactory =
+        eventNameMap => new JsonStringEventSerializer(eventNameMap);
+
+    private Lazy<IStreamStore> _streamStore;
+    private Func<IEventNameMap, IEventSerializer<string>> _eventSerializerFactory;
+    private ConcurrentDictionary<IEventNameMap, IEventSerializer<string>> _eventSerializers = new();
+
+    public SqlStreamStoreOptions()
+    {
+    }
+
+    private SqlStreamStoreOptions(SqlStreamStoreOptions copyFrom)
+    {
+        _streamStore = copyFrom._streamStore;
+        _eventSerializerFactory = copyFrom._eventSerializerFactory ?? DefaultEventSerializerFactory;
+        _eventSerializers = copyFrom._eventSerializers;
+    }
+
+    public SqlStreamStoreOptions WithStreamStoreFactory(Func<IStreamStore> factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+        return new SqlStreamStoreOptions(this) { _streamStore = new Lazy<IStreamStore>(factory) };
+    }
+
+    public SqlStreamStoreOptions WithEventSerializerFactory(Func<IEventNameMap, IEventSerializer<string>> factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+        return new SqlStreamStoreOptions(this)
+        {
+            _eventSerializerFactory = factory,
+
+            // As the factory has changed, we should also clear any existing cached serializers.
+            _eventSerializers = new ConcurrentDictionary<IEventNameMap, IEventSerializer<string>>()
+        };
+    }
+
+    public IStreamStore GetOrCreateStreamStore()
+    {
+        if (_streamStore == null)
+        {
+            throw new InvalidOperationException("Cannot create stream store as no factory has been specified.");
+        }
+
+        return _streamStore.Value;
+    }
+
+    public IEventSerializer<string> GetOrCreateEventSerializer(IEventNameMap eventNameMap)
+    {
+        if (eventNameMap == null) throw new ArgumentNullException(nameof(eventNameMap));
+
+        return _eventSerializers.GetOrAdd(eventNameMap, _eventSerializerFactory);
+    }
+}

--- a/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptionsBuilder.cs
+++ b/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptionsBuilder.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.Json;
+using DomainBlocks.Serialization.Json;
+using SqlStreamStore;
+
+namespace DomainBlocks.Persistence.SqlStreamStore.New;
+
+public class SqlStreamStoreOptionsBuilder
+{
+    public SqlStreamStoreOptions Options { get; private set; } = new();
+
+    public SqlStreamStoreOptionsBuilder UseJsonSerialization(JsonSerializerOptions jsonSerializerOptions = null)
+    {
+        Options = Options.WithEventSerializerFactory(
+            eventNameMap => new JsonStringEventSerializer(eventNameMap, jsonSerializerOptions));
+
+        return this;
+    }
+
+    internal void WithStreamStoreFactory(Func<IStreamStore> factory)
+    {
+        Options = Options.WithStreamStoreFactory(factory);
+    }
+}

--- a/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptionsBuilderExtensions.cs
+++ b/src/DomainBlocks.Persistence.SqlStreamStore/New/SqlStreamStoreOptionsBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using SqlStreamStore;
+
+namespace DomainBlocks.Persistence.SqlStreamStore.New;
+
+public static class SqlStreamStoreOptionsBuilderExtensions
+{
+    // Having this as an extension method allows us to move it to a different assembly. Consider moving this method out
+    // to a separate infrastructure specific assembly.
+    public static SqlStreamStoreOptionsBuilder UsePostgres(
+        this SqlStreamStoreOptionsBuilder optionsBuilder, PostgresStreamStoreSettings settings)
+    {
+        if (optionsBuilder == null) throw new ArgumentNullException(nameof(optionsBuilder));
+        if (settings == null) throw new ArgumentNullException(nameof(settings));
+        
+        optionsBuilder.WithStreamStoreFactory(() =>
+        {
+            var streamStore = new PostgresStreamStore(settings);
+            streamStore.CreateSchemaIfNotExists().Wait();
+            return streamStore;
+        });
+
+        return optionsBuilder;
+    }
+}

--- a/src/DomainBlocks.Persistence/AggregateRepository.cs
+++ b/src/DomainBlocks.Persistence/AggregateRepository.cs
@@ -30,7 +30,7 @@ public sealed class AggregateRepository<TRawData> : IAggregateRepository
     }
 
     public async Task<LoadedAggregate<TAggregateState>> LoadAsync<TAggregateState>(
-        string id, 
+        string id,
         AggregateLoadStrategy loadStrategy = AggregateLoadStrategy.PreferSnapshot, 
         CancellationToken cancellationToken = default)
     {

--- a/src/DomainBlocks.Persistence/New/AggregateRepositoryOptions.cs
+++ b/src/DomainBlocks.Persistence/New/AggregateRepositoryOptions.cs
@@ -1,0 +1,56 @@
+using System;
+using DomainBlocks.Core;
+
+namespace DomainBlocks.Persistence.New;
+
+public class AggregateRepositoryOptions
+{
+    private Func<Model, IAggregateRepository> _aggregateRepositoryFactory;
+    private Func<IEventNameMap, ISnapshotRepository> _snapshotRepositoryFactory;
+
+    public AggregateRepositoryOptions()
+    {
+    }
+
+    private AggregateRepositoryOptions(AggregateRepositoryOptions copyFrom)
+    {
+        _aggregateRepositoryFactory = copyFrom._aggregateRepositoryFactory;
+        _snapshotRepositoryFactory = copyFrom._snapshotRepositoryFactory;
+    }
+
+    public AggregateRepositoryOptions WithAggregateRepositoryFactory(Func<Model, IAggregateRepository> factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+        return new AggregateRepositoryOptions(this) { _aggregateRepositoryFactory = factory };
+    }
+
+    public AggregateRepositoryOptions WithSnapshotRepositoryFactory(Func<IEventNameMap, ISnapshotRepository> factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+        return new AggregateRepositoryOptions(this) { _snapshotRepositoryFactory = factory };
+    }
+
+    public IAggregateRepository CreateAggregateRepository(Model model)
+    {
+        if (model == null) throw new ArgumentNullException(nameof(model));
+
+        if (_aggregateRepositoryFactory == null)
+        {
+            throw new InvalidOperationException("Cannot create aggregate repository as no factory has been specified.");
+        }
+
+        return _aggregateRepositoryFactory(model);
+    }
+
+    public ISnapshotRepository CreateSnapshotRepository(IEventNameMap eventNameMap)
+    {
+        if (_snapshotRepositoryFactory == null)
+        {
+            throw new InvalidOperationException("Cannot create snapshot repository as no factory has been specified.");
+        }
+
+        return _snapshotRepositoryFactory(eventNameMap);
+    }
+}

--- a/src/DomainBlocks.Persistence/New/AggregateRepositoryOptionsBuilder.cs
+++ b/src/DomainBlocks.Persistence/New/AggregateRepositoryOptionsBuilder.cs
@@ -1,0 +1,21 @@
+using System;
+using DomainBlocks.Core;
+
+namespace DomainBlocks.Persistence.New;
+
+public class AggregateRepositoryOptionsBuilder : IAggregateRepositoryOptionsBuilderInfrastructure
+{
+    public AggregateRepositoryOptions Options { get; private set; } = new();
+
+    void IAggregateRepositoryOptionsBuilderInfrastructure.WithAggregateRepositoryFactory(
+        Func<Model, IAggregateRepository> factory)
+    {
+        Options = Options.WithAggregateRepositoryFactory(factory);
+    }
+
+    void IAggregateRepositoryOptionsBuilderInfrastructure.WithSnapshotRepositoryFactory(
+        Func<IEventNameMap, ISnapshotRepository> factory)
+    {
+        Options = Options.WithSnapshotRepositoryFactory(factory);
+    }
+}

--- a/src/DomainBlocks.Persistence/New/IAggregateRepositoryOptionsBuilderInfrastructure.cs
+++ b/src/DomainBlocks.Persistence/New/IAggregateRepositoryOptionsBuilderInfrastructure.cs
@@ -1,0 +1,10 @@
+using System;
+using DomainBlocks.Core;
+
+namespace DomainBlocks.Persistence.New;
+
+public interface IAggregateRepositoryOptionsBuilderInfrastructure
+{
+    void WithAggregateRepositoryFactory(Func<Model, IAggregateRepository> factory);
+    void WithSnapshotRepositoryFactory(Func<IEventNameMap, ISnapshotRepository> factory);
+}


### PR DESCRIPTION
This is only a starting point. We'll need to wire up EventStore, and update the builders to support snapshot repositories with different infra.

We'll soon be able to remove the old options builder code everywhere.

Changes made:

- Support SQLStreamStore with postgres as a starting point
- We no longer need to know about the raw event type
- Using the newer approach for options builders
- Pass in the `IServiceProvider` to the config builder action - allows for retrieving options from a registered `IOptions<T>`, for example.
- Pass in the `IServiceProvider` to the model builder action - allows for scenarios where you might want to construct an aggregate with something from the container.