### PR TITLE
Improve ApplyEventsBehavior enum readability

### DIFF
--- a/src/DomainBlocks.Core.Tests/Builders/ModelBuilderTests.cs
+++ b/src/DomainBlocks.Core.Tests/Builders/ModelBuilderTests.cs
@@ -67,7 +67,7 @@ public class ModelBuilderTests
             {
                 aggregate
                     .WithEventEnumerableCommandResult()
-                    .ApplyEvents(ApplyEventsBehavior.ApplyWhileEnumerating);
+                    .ApplyEvents(ApplyEventsBehavior.WhileEnumerating);
 
                 aggregate
                     .DiscoverEventApplierMethods()

--- a/src/DomainBlocks.Core.Tests/MutableCommandExecutionContextTests.cs
+++ b/src/DomainBlocks.Core.Tests/MutableCommandExecutionContextTests.cs
@@ -12,7 +12,7 @@ public class MutableCommandExecutionContextTests
     public void EventEnumerableReturnTypeIsNotEnumeratedAgainWhenMaterializing()
     {
         var builder = new MutableAggregateOptionsBuilder<MutableAggregate, IEvent>();
-        builder.WithEventEnumerableCommandResult().ApplyEvents(ApplyEventsBehavior.ApplyWhileEnumerating);
+        builder.WithEventEnumerableCommandResult().ApplyEvents(ApplyEventsBehavior.WhileEnumerating);
         builder.ApplyEventsWith((agg, e) => agg.Apply((dynamic)e));
         var options = builder.Options;
 

--- a/src/DomainBlocks.Core/ApplyEventsBehavior.cs
+++ b/src/DomainBlocks.Core/ApplyEventsBehavior.cs
@@ -6,7 +6,7 @@ public enum ApplyEventsBehavior
     /// Do not apply the events to the aggregate. Specify this behavior when the aggregate's state is updated by
     /// the command method.
     /// </summary>
-    DoNotApply,
+    Never,
 
     /// <summary>
     /// Materialize the event enumerable prior to applying each event to the aggregate. Specify this behavior to
@@ -18,5 +18,5 @@ public enum ApplyEventsBehavior
     /// Apply the returned events to the aggregate while enumerating them. Specify this behavior to update the state of
     /// the aggregate as events are yield returned from the command method.
     /// </summary>
-    ApplyWhileEnumerating
+    WhileEnumerating
 }

--- a/src/DomainBlocks.Core/MutableEventEnumerableCommandResultOptions.cs
+++ b/src/DomainBlocks.Core/MutableEventEnumerableCommandResultOptions.cs
@@ -7,7 +7,7 @@ namespace DomainBlocks.Core;
 public sealed class MutableEventEnumerableCommandResultOptions<TAggregate, TEventBase> :
     IMutableCommandResultOptions<TAggregate, IEnumerable<TEventBase>> where TEventBase : class
 {
-    private ApplyEventsBehavior _behavior = ApplyEventsBehavior.DoNotApply;
+    private ApplyEventsBehavior _behavior = ApplyEventsBehavior.Never;
 
     public MutableEventEnumerableCommandResultOptions()
     {
@@ -35,9 +35,9 @@ public sealed class MutableEventEnumerableCommandResultOptions<TAggregate, TEven
     {
         return _behavior switch
         {
-            ApplyEventsBehavior.DoNotApply => commandResult.ToList().AsReadOnly(),
+            ApplyEventsBehavior.Never => commandResult.ToList().AsReadOnly(),
             ApplyEventsBehavior.MaterializeFirst => ApplyAfterEnumerating(commandResult, state, eventApplier),
-            ApplyEventsBehavior.ApplyWhileEnumerating => ApplyWhileEnumerating(commandResult, state, eventApplier),
+            ApplyEventsBehavior.WhileEnumerating => ApplyWhileEnumerating(commandResult, state, eventApplier),
             _ => throw new InvalidOperationException($"Unknown enum value {nameof(ApplyEventsBehavior)}.{_behavior}.")
         };
     }


### PR DESCRIPTION
`Never` is a more standard name used in libraries such as EntityFramework. Also, there is no need to repeat the word "Apply" in `ApplyWhileEnumerating`.