### PR TITLE
Preparation for process managers

### DIFF
--- a/benchmarks/DomainBlocks.Core.Benchmarks/EntityIdSelectorBenchmark.cs
+++ b/benchmarks/DomainBlocks.Core.Benchmarks/EntityIdSelectorBenchmark.cs
@@ -3,11 +3,11 @@ using BenchmarkDotNet.Attributes;
 namespace DomainBlocks.Core.Benchmarks;
 
 [MemoryDiagnoser]
-public class AggregateIdSelectorBenchmark
+public class EntityIdSelectorBenchmark
 {
     private const int Iterations = 1000;
-    private AggregateTypeBase<MyAggregate, object> _typeWithExplicitIdSelector;
-    private AggregateTypeBase<MyAggregate, object> _typeWithDefaultIdSelector;
+    private EventSourcedEntityTypeBase<MyAggregate> _typeWithExplicitIdSelector;
+    private EventSourcedEntityTypeBase<MyAggregate> _typeWithDefaultIdSelector;
     private MyAggregate _aggregate;
 
     [GlobalSetup]

--- a/benchmarks/DomainBlocks.Core.Benchmarks/ImmutableEventApplierBenchmarks.cs
+++ b/benchmarks/DomainBlocks.Core.Benchmarks/ImmutableEventApplierBenchmarks.cs
@@ -27,17 +27,17 @@ public class ImmutableEventApplierBenchmark
 
         var builder = new ImmutableAggregateTypeBuilder<ImmutableAggregate, TestEvents.IEvent>();
         builder.AutoConfigureEvents();
-        _autoConfiguredEventAppliersType = builder.AggregateType;
+        _autoConfiguredEventAppliersType = builder.Build();
 
         builder = new ImmutableAggregateTypeBuilder<ImmutableAggregate, TestEvents.IEvent>();
         builder.AutoConfigureEventsFrom(typeof(ImmutableAggregateFunctions));
-        _autoConfiguredNonMemberEventAppliersType = builder.AggregateType;
+        _autoConfiguredNonMemberEventAppliersType = builder.Build();
 
         builder = new ImmutableAggregateTypeBuilder<ImmutableAggregate, TestEvents.IEvent>();
         builder.Event<TestEvents.Event1>().ApplyWith((agg, e) => agg.Apply(e));
         builder.Event<TestEvents.Event2>().ApplyWith((agg, e) => agg.Apply(e));
         builder.Event<TestEvents.Event3>().ApplyWith((agg, e) => agg.Apply(e));
-        _manuallyConfiguredEventAppliersType = builder.AggregateType;
+        _manuallyConfiguredEventAppliersType = builder.Build();
 
         _aggregate = new ImmutableAggregate();
     }

--- a/benchmarks/DomainBlocks.Core.Benchmarks/MutableEventApplierBenchmark.cs
+++ b/benchmarks/DomainBlocks.Core.Benchmarks/MutableEventApplierBenchmark.cs
@@ -25,13 +25,13 @@ public class MutableEventApplierBenchmark
 
         var builder = new MutableAggregateTypeBuilder<MutableAggregate, TestEvents.IEvent>();
         builder.AutoConfigureEvents();
-        _autoConfiguredEventAppliersType = builder.AggregateType;
+        _autoConfiguredEventAppliersType = builder.Build();
 
         builder = new MutableAggregateTypeBuilder<MutableAggregate, TestEvents.IEvent>();
         builder.Event<TestEvents.Event1>().ApplyWith((agg, e) => agg.Apply(e));
         builder.Event<TestEvents.Event2>().ApplyWith((agg, e) => agg.Apply(e));
         builder.Event<TestEvents.Event3>().ApplyWith((agg, e) => agg.Apply(e));
-        _manuallyConfiguredEventAppliersType = builder.AggregateType;
+        _manuallyConfiguredEventAppliersType = builder.Build();
 
         _aggregate = new MutableAggregate();
     }

--- a/src/DomainBlocks.Core/AggregateTypeBase.cs
+++ b/src/DomainBlocks.Core/AggregateTypeBase.cs
@@ -1,85 +1,27 @@
-using System.Linq.Expressions;
-
 namespace DomainBlocks.Core;
 
-public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType<TAggregate>
+public abstract class AggregateTypeBase<TAggregate, TEventBase> :
+    EventSourcedEntityTypeBase<TAggregate>,
+    IAggregateType<TAggregate>
 {
-    private static readonly Lazy<Func<TAggregate>> DefaultFactory = new(() => GetDefaultFactory());
-    private static readonly Lazy<Func<TAggregate, string>> DefaultIdSelector = new(GetDefaultIdSelector);
     private readonly Dictionary<Type, ICommandResultType> _commandResultTypes = new();
     private readonly Dictionary<Type, AggregateEventType<TAggregate>> _eventTypes = new();
-    private Func<TAggregate> _factory;
-    private Func<TAggregate, string> _idSelector;
-    private Func<string, string> _idToStreamKeySelector;
-    private Func<string, string> _idToSnapshotKeySelector;
     private Func<TAggregate, object, TAggregate>? _eventApplier;
 
     protected AggregateTypeBase()
     {
-        _factory = DefaultFactory.Value;
-        _idSelector = DefaultIdSelector.Value;
-        var prefix = GetDefaultKeyPrefix();
-        _idToStreamKeySelector = GetIdToStreamKeySelector(prefix);
-        _idToSnapshotKeySelector = GetIdToSnapshotKeySelector(prefix);
     }
 
-    protected AggregateTypeBase(AggregateTypeBase<TAggregate, TEventBase> copyFrom)
+    protected AggregateTypeBase(AggregateTypeBase<TAggregate, TEventBase> copyFrom) : base(copyFrom)
     {
         if (copyFrom == null) throw new ArgumentNullException(nameof(copyFrom));
 
         _eventApplier = copyFrom._eventApplier;
-        _factory = copyFrom._factory;
-        _idSelector = copyFrom._idSelector;
-        _idToStreamKeySelector = copyFrom._idToStreamKeySelector;
-        _idToSnapshotKeySelector = copyFrom._idToSnapshotKeySelector;
         _commandResultTypes = new Dictionary<Type, ICommandResultType>(copyFrom._commandResultTypes);
         _eventTypes = new Dictionary<Type, AggregateEventType<TAggregate>>(copyFrom._eventTypes);
     }
 
-    public Type ClrType => typeof(TAggregate);
-    public IEnumerable<IEventType> EventTypes => _eventTypes.Values;
-
-    public TAggregate CreateNew()
-    {
-        if (_factory == null)
-        {
-            throw new InvalidOperationException(
-                "Cannot create new aggregate instance as no factory has been specified.");
-        }
-
-        return _factory();
-    }
-
-    public string GetId(TAggregate aggregate)
-    {
-        if (aggregate == null) throw new ArgumentNullException(nameof(aggregate));
-
-        if (_idSelector == null)
-        {
-            throw new InvalidOperationException("Cannot get ID as no ID selector has been specified.");
-        }
-
-        return _idSelector(aggregate);
-    }
-
-    public string MakeStreamKey(string id)
-    {
-        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("ID cannot be null or whitespace", nameof(id));
-
-        return _idToStreamKeySelector(id);
-    }
-
-    public string MakeSnapshotKey(string id)
-    {
-        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("ID cannot be null or whitespace", nameof(id));
-
-        return _idToSnapshotKeySelector(id);
-    }
-
-    public string MakeSnapshotKey(TAggregate aggregate)
-    {
-        return MakeSnapshotKey(GetId(aggregate));
-    }
+    public override IEnumerable<IEventType> EventTypes => _eventTypes.Values;
 
     public abstract ICommandExecutionContext<TAggregate> CreateCommandExecutionContext(TAggregate aggregate);
 
@@ -103,61 +45,12 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
             "applier was found.");
     }
 
-    public AggregateTypeBase<TAggregate, TEventBase> SetFactory(Func<TAggregate> factory)
-    {
-        if (factory == null) throw new ArgumentNullException(nameof(factory));
-
-        var clone = Clone();
-        clone._factory = factory;
-        return clone;
-    }
-
-    public AggregateTypeBase<TAggregate, TEventBase> SetIdSelector(Func<TAggregate, string> idSelector)
-    {
-        if (idSelector == null) throw new ArgumentNullException(nameof(idSelector));
-
-        var clone = Clone();
-        clone._idSelector = idSelector;
-        return clone;
-    }
-
-    public AggregateTypeBase<TAggregate, TEventBase> SetKeyPrefix(string prefix)
-    {
-        if (string.IsNullOrWhiteSpace(prefix))
-            throw new ArgumentException("Prefix cannot be null or whitespace.", nameof(prefix));
-
-        var clone = Clone();
-        clone._idToStreamKeySelector = GetIdToStreamKeySelector(prefix);
-        clone._idToSnapshotKeySelector = GetIdToSnapshotKeySelector(prefix);
-        return clone;
-    }
-
-    public AggregateTypeBase<TAggregate, TEventBase> SetIdToStreamKeySelector(
-        Func<string, string> idToStreamKeySelector)
-    {
-        if (idToStreamKeySelector == null) throw new ArgumentNullException(nameof(idToStreamKeySelector));
-
-        var clone = Clone();
-        clone._idToStreamKeySelector = idToStreamKeySelector;
-        return clone;
-    }
-
-    public AggregateTypeBase<TAggregate, TEventBase> SetIdToSnapshotKeySelector(
-        Func<string, string> idToSnapshotKeySelector)
-    {
-        if (idToSnapshotKeySelector == null) throw new ArgumentNullException(nameof(idToSnapshotKeySelector));
-
-        var clone = Clone();
-        clone._idToSnapshotKeySelector = idToSnapshotKeySelector;
-        return clone;
-    }
-
     public AggregateTypeBase<TAggregate, TEventBase> SetEventApplier(
         Func<TAggregate, TEventBase, TAggregate> eventApplier)
     {
         if (eventApplier == null) throw new ArgumentNullException(nameof(eventApplier));
 
-        var clone = Clone();
+        var clone = CloneImpl();
         clone._eventApplier = (agg, e) => eventApplier(agg, (TEventBase)e);
         return clone;
     }
@@ -166,7 +59,7 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
     {
         if (commandResultType == null) throw new ArgumentNullException(nameof(commandResultType));
 
-        var clone = Clone();
+        var clone = CloneImpl();
         clone._commandResultTypes[commandResultType.ClrType] = commandResultType;
         return clone;
     }
@@ -176,7 +69,7 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
     {
         if (commandResultTypes == null) throw new ArgumentNullException(nameof(commandResultTypes));
 
-        var clone = Clone();
+        var clone = CloneImpl();
 
         foreach (var commandResultType in commandResultTypes)
         {
@@ -191,7 +84,7 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
     {
         if (eventTypes == null) throw new ArgumentNullException(nameof(eventTypes));
 
-        var clone = Clone();
+        var clone = CloneImpl();
 
         foreach (var eventType in eventTypes)
         {
@@ -213,8 +106,6 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
         return _commandResultTypes.ContainsKey(typeof(TCommandResult));
     }
 
-    protected abstract AggregateTypeBase<TAggregate, TEventBase> Clone();
-
     protected ICommandResultType GetCommandResultType<TCommandResult>()
     {
         var commandResultClrType = typeof(TCommandResult);
@@ -227,60 +118,5 @@ public abstract class AggregateTypeBase<TAggregate, TEventBase> : IAggregateType
         throw new KeyNotFoundException($"No command result type found for CLR type {commandResultClrType.Name}.");
     }
 
-    private static Func<TAggregate> GetDefaultFactory()
-    {
-        var ctor = typeof(TAggregate).GetConstructor(Type.EmptyTypes);
-        if (ctor == null)
-        {
-            return () => throw new InvalidOperationException(
-                "No factory function specified, and no default constructor found");
-        }
-
-        var newExpr = Expression.New(ctor);
-        var lambda = Expression.Lambda<Func<TAggregate>>(newExpr);
-        return lambda.Compile();
-    }
-
-    private static Func<TAggregate, string> GetDefaultIdSelector()
-    {
-        const string defaultIdPropertyName = "Id";
-
-        var idSelector =
-            (GetIdSelector(defaultIdPropertyName) ??
-             GetIdSelector($"{typeof(TAggregate).Name}{defaultIdPropertyName}")) ??
-            (_ => throw new InvalidOperationException("No ID selector specified, and no suitable ID property found"));
-
-        return idSelector;
-    }
-
-    private static Func<TAggregate, string>? GetIdSelector(string propertyName)
-    {
-        var property = typeof(TAggregate).GetProperty(propertyName);
-        if (property == null)
-        {
-            return null;
-        }
-
-        var aggregateParam = Expression.Parameter(typeof(TAggregate));
-        var propertyExpr = Expression.Property(aggregateParam, property);
-        var asString = Expression.Call(propertyExpr, nameof(ToString), null);
-        var lambda = Expression.Lambda<Func<TAggregate, string>>(asString, aggregateParam);
-        return lambda.Compile();
-    }
-
-    private static string GetDefaultKeyPrefix()
-    {
-        var name = typeof(TAggregate).Name;
-        return $"{name[..1].ToLower()}{name[1..]}";
-    }
-
-    private static Func<string, string> GetIdToStreamKeySelector(string prefix)
-    {
-        return id => $"{prefix}-{id}";
-    }
-
-    private static Func<string, string> GetIdToSnapshotKeySelector(string prefix)
-    {
-        return id => $"{prefix}Snapshot-{id}";
-    }
+    private AggregateTypeBase<TAggregate, TEventBase> CloneImpl() => (AggregateTypeBase<TAggregate, TEventBase>)Clone();
 }

--- a/src/DomainBlocks.Core/Builders/AggregateTypeBuilderBase.cs
+++ b/src/DomainBlocks.Core/Builders/AggregateTypeBuilderBase.cs
@@ -2,114 +2,18 @@ using System.Reflection;
 
 namespace DomainBlocks.Core.Builders;
 
-public interface IAggregateTypeBuilder
-{
-    IAggregateType AggregateType { get; }
-}
-
-public interface IIdentityBuilder<out TAggregate> : IKeyPrefixBuilder
-{
-    /// <summary>
-    /// Specify a unique ID selector for the aggregate.
-    /// </summary>
-    /// <returns>
-    /// An object that can be used for further configuration.
-    /// </returns>
-    IKeyBuilder HasId(Func<TAggregate, string> idSelector);
-}
-
-public interface IKeyPrefixBuilder
-{
-    /// <summary>
-    /// Specify a prefix to use for both stream and snapshot keys.
-    /// </summary>
-    void WithKeyPrefix(string prefix);
-}
-
-public interface IKeyBuilder : IKeyPrefixBuilder, ISnapshotKeyBuilder
-{
-    /// <summary>
-    /// Specify a stream key selector.
-    /// </summary>
-    /// <returns>
-    /// An object that can be used for further configuration.
-    /// </returns>
-    ISnapshotKeyBuilder WithStreamKey(Func<string, string> idToStreamKeySelector);
-}
-
-public interface ISnapshotKeyBuilder
-{
-    /// <summary>
-    /// Specify a snapshot key selector.
-    /// </summary>
-    void WithSnapshotKey(Func<string, string> idToSnapshotKeySelector);
-}
-
 public abstract class AggregateTypeBuilderBase<TAggregate, TEventBase> :
-    IAggregateTypeBuilder,
-    IIdentityBuilder<TAggregate>,
-    IKeyBuilder
+    EventSourcedEntityTypeBuilderBase<TAggregate>,
+    IAggregateTypeBuilder
 {
-    public IAggregateType<TAggregate> AggregateType
+    // ReSharper disable once SuggestBaseTypeForParameterInConstructor - we want to ensure the derived type here.
+    protected AggregateTypeBuilderBase(AggregateTypeBase<TAggregate, TEventBase> aggregateType) : base(aggregateType)
     {
-        get
-        {
-            var aggregateType = AggregateTypeImpl;
-
-            if (AutoEventTypeBuilder != null)
-            {
-                aggregateType = aggregateType.SetEventTypes(AutoEventTypeBuilder.Build());
-            }
-
-            // Any individually configured event types will override auto configured event types for a given CLR type.
-            var eventTypes = EventTypeBuilders.Select(x => x.EventType);
-            aggregateType = aggregateType.SetEventTypes(eventTypes);
-
-            return aggregateType;
-        }
     }
-
-    IAggregateType IAggregateTypeBuilder.AggregateType => AggregateType;
-
-    protected abstract AggregateTypeBase<TAggregate, TEventBase> AggregateTypeImpl { get; set; }
 
     internal IAutoAggregateEventTypeBuilder<TAggregate>? AutoEventTypeBuilder { get; set; }
 
     internal List<IAggregateEventTypeBuilder<TAggregate>> EventTypeBuilders { get; } = new();
-
-    /// <summary>
-    /// Specify a factory function for creating new instances of the aggregate type.
-    /// </summary>
-    /// <returns>
-    /// An object that can be used for further configuration.
-    /// </returns>
-    public IIdentityBuilder<TAggregate> InitialState(Func<TAggregate> factory)
-    {
-        AggregateTypeImpl = AggregateTypeImpl.SetFactory(factory);
-        return this;
-    }
-
-    public IKeyBuilder HasId(Func<TAggregate, string> idSelector)
-    {
-        AggregateTypeImpl = AggregateTypeImpl.SetIdSelector(idSelector);
-        return this;
-    }
-
-    public void WithKeyPrefix(string prefix)
-    {
-        AggregateTypeImpl = AggregateTypeImpl.SetKeyPrefix(prefix);
-    }
-
-    ISnapshotKeyBuilder IKeyBuilder.WithStreamKey(Func<string, string> idToStreamKeySelector)
-    {
-        AggregateTypeImpl = AggregateTypeImpl.SetIdToStreamKeySelector(idToStreamKeySelector);
-        return this;
-    }
-
-    void ISnapshotKeyBuilder.WithSnapshotKey(Func<string, string> idToSnapshotKeySelector)
-    {
-        AggregateTypeImpl = AggregateTypeImpl.SetIdToSnapshotKeySelector(idToSnapshotKeySelector);
-    }
 
     /// <summary>
     /// Finds events deriving from type <see cref="TEventBase"/> in the specified assembly, and adds them to the
@@ -123,5 +27,21 @@ public abstract class AggregateTypeBuilderBase<TAggregate, TEventBase> :
         var builder = new AssemblyAggregateEventTypeBuilder<TAggregate, TEventBase>(assembly);
         AutoEventTypeBuilder = builder;
         return builder;
+    }
+
+    public new IAggregateType Build() => (IAggregateType)base.Build();
+
+    protected override EventSourcedEntityTypeBase<TAggregate> OnBuild(EventSourcedEntityTypeBase<TAggregate> source)
+    {
+        var aggregateType = (AggregateTypeBase<TAggregate, TEventBase>)source;
+        if (AutoEventTypeBuilder != null)
+        {
+            aggregateType = aggregateType.SetEventTypes(AutoEventTypeBuilder.Build());
+        }
+
+        // Any individually configured event types will override auto configured event types for a given CLR type.
+        var eventTypes = EventTypeBuilders.Select(x => x.EventType);
+        aggregateType = aggregateType.SetEventTypes(eventTypes);
+        return aggregateType;
     }
 }

--- a/src/DomainBlocks.Core/Builders/AssemblyAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/AssemblyAggregateEventTypeBuilder.cs
@@ -2,15 +2,6 @@
 
 namespace DomainBlocks.Core.Builders;
 
-public interface ITypeFilterBuilder
-{
-    /// <summary>
-    /// Specify an additional filter to use on the event types which have been found in the specified assembly. The
-    /// argument of the predicate is a type derived from the specified base event type.
-    /// </summary>
-    void Where(Func<Type, bool> predicate);
-}
-
 internal sealed class AssemblyAggregateEventTypeBuilder<TAggregate, TEventBase> :
     IAutoAggregateEventTypeBuilder<TAggregate>,
     ITypeFilterBuilder

--- a/src/DomainBlocks.Core/Builders/AutoAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/AutoAggregateEventTypeBuilder.cs
@@ -3,25 +3,6 @@ using System.Reflection;
 
 namespace DomainBlocks.Core.Builders;
 
-public interface IAutoEventTypeBuilder : IMethodVisibilityBuilder
-{
-    /// <summary>
-    /// Specify the name of the event applier method overloads on the aggregate type.
-    /// </summary>
-    /// <returns>
-    /// An object that can be used for further configuration.
-    /// </returns>
-    IMethodVisibilityBuilder WithMethodName(string methodName);
-}
-
-public interface IMethodVisibilityBuilder
-{
-    /// <summary>
-    /// Specify to include non-public event applier methods.
-    /// </summary>
-    void IncludeNonPublicMethods();
-}
-
 internal sealed class AutoAggregateEventTypeBuilder<TAggregate, TEventBase> :
     IAutoEventTypeBuilder,
     IAutoAggregateEventTypeBuilder<TAggregate>

--- a/src/DomainBlocks.Core/Builders/EventSourcedEntityTypeBuilderBase.cs
+++ b/src/DomainBlocks.Core/Builders/EventSourcedEntityTypeBuilderBase.cs
@@ -13,7 +13,7 @@ public abstract class EventSourcedEntityTypeBuilderBase<TEntity> :
     protected EventSourcedEntityTypeBase<TEntity> EntityType { get; set; }
 
     /// <summary>
-    /// Specify a factory function for creating new instances of the aggregate type.
+    /// Specify a factory function for creating new instances of the entity type.
     /// </summary>
     /// <returns>
     /// An object that can be used for further configuration.

--- a/src/DomainBlocks.Core/Builders/EventSourcedEntityTypeBuilderBase.cs
+++ b/src/DomainBlocks.Core/Builders/EventSourcedEntityTypeBuilderBase.cs
@@ -1,0 +1,55 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public abstract class EventSourcedEntityTypeBuilderBase<TEntity> :
+    IEventSourcedEntityTypeBuilder,
+    IIdentityBuilder<TEntity>,
+    IKeyBuilder
+{
+    protected EventSourcedEntityTypeBuilderBase(EventSourcedEntityTypeBase<TEntity> entityType)
+    {
+        EntityType = entityType;
+    }
+
+    protected EventSourcedEntityTypeBase<TEntity> EntityType { get; set; }
+
+    /// <summary>
+    /// Specify a factory function for creating new instances of the aggregate type.
+    /// </summary>
+    /// <returns>
+    /// An object that can be used for further configuration.
+    /// </returns>
+    public IIdentityBuilder<TEntity> InitialState(Func<TEntity> factory)
+    {
+        EntityType = EntityType.SetFactory(factory);
+        return this;
+    }
+
+    public IKeyBuilder HasId(Func<TEntity, string> idSelector)
+    {
+        EntityType = EntityType.SetIdSelector(idSelector);
+        return this;
+    }
+
+    public void WithKeyPrefix(string prefix)
+    {
+        EntityType = EntityType.SetKeyPrefix(prefix);
+    }
+
+    ISnapshotKeyBuilder IKeyBuilder.WithStreamKey(Func<string, string> idToStreamKeySelector)
+    {
+        EntityType = EntityType.SetIdToStreamKeySelector(idToStreamKeySelector);
+        return this;
+    }
+
+    void ISnapshotKeyBuilder.WithSnapshotKey(Func<string, string> idToSnapshotKeySelector)
+    {
+        EntityType = EntityType.SetIdToSnapshotKeySelector(idToSnapshotKeySelector);
+    }
+
+    public IEventSourcedEntityType Build()
+    {
+        return OnBuild(EntityType);
+    }
+
+    protected abstract EventSourcedEntityTypeBase<TEntity> OnBuild(EventSourcedEntityTypeBase<TEntity> source);
+}

--- a/src/DomainBlocks.Core/Builders/IAggregateTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IAggregateTypeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IAggregateTypeBuilder : IEventSourcedEntityTypeBuilder
+{
+    new IAggregateType Build();
+}

--- a/src/DomainBlocks.Core/Builders/IAutoEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IAutoEventTypeBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IAutoEventTypeBuilder : IMethodVisibilityBuilder
+{
+    /// <summary>
+    /// Specify the name of the event applier method overloads on the aggregate type.
+    /// </summary>
+    /// <returns>
+    /// An object that can be used for further configuration.
+    /// </returns>
+    IMethodVisibilityBuilder WithMethodName(string methodName);
+}

--- a/src/DomainBlocks.Core/Builders/IEventSourcedEntityTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IEventSourcedEntityTypeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IEventSourcedEntityTypeBuilder
+{
+    IEventSourcedEntityType Build();
+}

--- a/src/DomainBlocks.Core/Builders/IIdentityBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IIdentityBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IIdentityBuilder<out TEntity> : IKeyPrefixBuilder
+{
+    /// <summary>
+    /// Specify a unique ID selector for the entity.
+    /// </summary>
+    /// <returns>
+    /// An object that can be used for further configuration.
+    /// </returns>
+    IKeyBuilder HasId(Func<TEntity, string> idSelector);
+}

--- a/src/DomainBlocks.Core/Builders/IImmutableAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IImmutableAggregateEventTypeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IImmutableAggregateEventTypeBuilder<TAggregate, out TEvent> : IEventNameBuilder
+{
+    IEventNameBuilder ApplyWith(Func<TAggregate, TEvent, TAggregate> eventApplier);
+}

--- a/src/DomainBlocks.Core/Builders/IImmutableCommandResultUpdatedStateBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IImmutableCommandResultUpdatedStateBuilder.cs
@@ -6,5 +6,5 @@ public interface IImmutableCommandResultUpdatedStateBuilder<in TAggregate, out T
     /// Specify where to select the updated aggregate state from in the command result object. Use this option when the
     /// command result contains the updated state of the aggregate.
     /// </summary>
-    public void WithUpdatedStateFrom(Func<TCommandResult, TAggregate> updatedStateSelector);
+    void WithUpdatedStateFrom(Func<TCommandResult, TAggregate> updatedStateSelector);
 }

--- a/src/DomainBlocks.Core/Builders/IImmutableCommandResultUpdatedStateBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IImmutableCommandResultUpdatedStateBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IImmutableCommandResultUpdatedStateBuilder<in TAggregate, out TCommandResult>
+{
+    /// <summary>
+    /// Specify where to select the updated aggregate state from in the command result object. Use this option when the
+    /// command result contains the updated state of the aggregate.
+    /// </summary>
+    public void WithUpdatedStateFrom(Func<TCommandResult, TAggregate> updatedStateSelector);
+}

--- a/src/DomainBlocks.Core/Builders/IKeyBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IKeyBuilder.cs
@@ -1,0 +1,12 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IKeyBuilder : IKeyPrefixBuilder, ISnapshotKeyBuilder
+{
+    /// <summary>
+    /// Specify a stream key selector.
+    /// </summary>
+    /// <returns>
+    /// An object that can be used for further configuration.
+    /// </returns>
+    ISnapshotKeyBuilder WithStreamKey(Func<string, string> idToStreamKeySelector);
+}

--- a/src/DomainBlocks.Core/Builders/IKeyPrefixBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IKeyPrefixBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IKeyPrefixBuilder
+{
+    /// <summary>
+    /// Specify a prefix to use for both stream and snapshot keys.
+    /// </summary>
+    void WithKeyPrefix(string prefix);
+}

--- a/src/DomainBlocks.Core/Builders/IMethodVisibilityBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IMethodVisibilityBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IMethodVisibilityBuilder
+{
+    /// <summary>
+    /// Specify to include non-public event applier methods.
+    /// </summary>
+    void IncludeNonPublicMethods();
+}

--- a/src/DomainBlocks.Core/Builders/IMutableAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IMutableAggregateEventTypeBuilder.cs
@@ -1,0 +1,6 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IMutableAggregateEventTypeBuilder<out TAggregate, out TEvent> : IEventNameBuilder
+{
+    IEventNameBuilder ApplyWith(Action<TAggregate, TEvent> eventApplier);
+}

--- a/src/DomainBlocks.Core/Builders/IMutableCommandResultTypeApplyEventsBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/IMutableCommandResultTypeApplyEventsBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface IMutableCommandResultTypeApplyEventsBuilder
+{
+    /// <summary>
+    /// Specify to update the aggregate's state by applying the returned events. Use this option when the mutable
+    /// aggregate's state is not updated by the command method.
+    /// </summary>
+    void ApplyEvents();
+}

--- a/src/DomainBlocks.Core/Builders/ISnapshotKeyBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/ISnapshotKeyBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface ISnapshotKeyBuilder
+{
+    /// <summary>
+    /// Specify a snapshot key selector.
+    /// </summary>
+    void WithSnapshotKey(Func<string, string> idToSnapshotKeySelector);
+}

--- a/src/DomainBlocks.Core/Builders/ITypeFilterBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/ITypeFilterBuilder.cs
@@ -1,0 +1,10 @@
+﻿namespace DomainBlocks.Core.Builders;
+
+public interface ITypeFilterBuilder
+{
+    /// <summary>
+    /// Specify an additional filter to use on the event types which have been found in the specified assembly. The
+    /// argument of the predicate is a type derived from the specified base event type.
+    /// </summary>
+    void Where(Func<Type, bool> predicate);
+}

--- a/src/DomainBlocks.Core/Builders/ImmutableAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/ImmutableAggregateEventTypeBuilder.cs
@@ -1,10 +1,5 @@
 namespace DomainBlocks.Core.Builders;
 
-public interface IImmutableAggregateEventTypeBuilder<TAggregate, out TEvent> : IEventNameBuilder
-{
-    IEventNameBuilder ApplyWith(Func<TAggregate, TEvent, TAggregate> eventApplier);
-}
-
 public sealed class ImmutableAggregateEventTypeBuilder<TAggregate, TEventBase, TEvent> :
     IAggregateEventTypeBuilder<TAggregate>,
     IImmutableAggregateEventTypeBuilder<TAggregate, TEvent>

--- a/src/DomainBlocks.Core/Builders/ImmutableCommandResultTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/ImmutableCommandResultTypeBuilder.cs
@@ -1,14 +1,5 @@
 namespace DomainBlocks.Core.Builders;
 
-public interface IImmutableCommandResultUpdatedStateBuilder<in TAggregate, out TCommandResult>
-{
-    /// <summary>
-    /// Specify where to select the updated aggregate state from in the command result object. Use this option when the
-    /// command result contains the updated state of the aggregate.
-    /// </summary>
-    public void WithUpdatedStateFrom(Func<TCommandResult, TAggregate> updatedStateSelector);
-}
-
 public sealed class ImmutableCommandResultTypeBuilder<TAggregate, TEventBase, TCommandResult> :
     ICommandResultTypeBuilder,
     IImmutableCommandResultUpdatedStateBuilder<TAggregate, TCommandResult>

--- a/src/DomainBlocks.Core/Builders/ModelBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/ModelBuilder.cs
@@ -30,7 +30,7 @@ public sealed class ModelBuilder
         builderAction(builder);
         return this;
     }
-    
+
     public ModelBuilder ImmutableAggregate<TAggregate>(
         Action<ImmutableAggregateTypeBuilder<TAggregate, object>> builderAction)
     {
@@ -39,7 +39,7 @@ public sealed class ModelBuilder
 
     public Model Build()
     {
-        var aggregateTypes = _aggregateTypeBuilders.Select(x => x.AggregateType);
+        var aggregateTypes = _aggregateTypeBuilders.Select(x => x.Build());
         return new Model(aggregateTypes);
     }
 }

--- a/src/DomainBlocks.Core/Builders/MutableAggregateEventTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/MutableAggregateEventTypeBuilder.cs
@@ -1,10 +1,5 @@
 namespace DomainBlocks.Core.Builders;
 
-public interface IMutableAggregateEventTypeBuilder<out TAggregate, out TEvent> : IEventNameBuilder
-{
-    IEventNameBuilder ApplyWith(Action<TAggregate, TEvent> eventApplier);
-}
-
 public sealed class MutableAggregateEventTypeBuilder<TAggregate, TEventBase, TEvent> :
     IAggregateEventTypeBuilder<TAggregate>,
     IMutableAggregateEventTypeBuilder<TAggregate, TEvent>

--- a/src/DomainBlocks.Core/Builders/MutableCommandResultTypeBuilder.cs
+++ b/src/DomainBlocks.Core/Builders/MutableCommandResultTypeBuilder.cs
@@ -1,14 +1,5 @@
 namespace DomainBlocks.Core.Builders;
 
-public interface IMutableCommandResultTypeApplyEventsBuilder
-{
-    /// <summary>
-    /// Specify to update the aggregate's state by applying the returned events. Use this option when the mutable
-    /// aggregate's state is not updated by the command method.
-    /// </summary>
-    void ApplyEvents();
-}
-
 public sealed class MutableCommandResultTypeBuilder<TAggregate, TEventBase, TCommandResult> :
     ICommandResultTypeBuilder, IMutableCommandResultTypeApplyEventsBuilder where TEventBase : class
 {

--- a/src/DomainBlocks.Core/EventSourcedEntityTypeBase.cs
+++ b/src/DomainBlocks.Core/EventSourcedEntityTypeBase.cs
@@ -1,0 +1,185 @@
+﻿using System.Linq.Expressions;
+
+namespace DomainBlocks.Core;
+
+public abstract class EventSourcedEntityTypeBase<TEntity> : IEventSourcedEntityType<TEntity>
+{
+    private static readonly Lazy<Func<TEntity>> DefaultFactory = new(() => GetDefaultFactory());
+    private static readonly Lazy<Func<TEntity, string>> DefaultIdSelector = new(GetDefaultIdSelector);
+    private Func<TEntity> _factory;
+    private Func<TEntity, string> _idSelector;
+    private Func<string, string> _idToStreamKeySelector;
+    private Func<string, string> _idToSnapshotKeySelector;
+
+    protected EventSourcedEntityTypeBase()
+    {
+        _factory = DefaultFactory.Value;
+        _idSelector = DefaultIdSelector.Value;
+        var prefix = GetDefaultKeyPrefix();
+        _idToStreamKeySelector = GetIdToStreamKeySelector(prefix);
+        _idToSnapshotKeySelector = GetIdToSnapshotKeySelector(prefix);
+    }
+
+    protected EventSourcedEntityTypeBase(EventSourcedEntityTypeBase<TEntity> copyFrom)
+    {
+        if (copyFrom == null) throw new ArgumentNullException(nameof(copyFrom));
+
+        _factory = copyFrom._factory;
+        _idSelector = copyFrom._idSelector;
+        _idToStreamKeySelector = copyFrom._idToStreamKeySelector;
+        _idToSnapshotKeySelector = copyFrom._idToSnapshotKeySelector;
+    }
+
+    public Type ClrType => typeof(TEntity);
+    public abstract IEnumerable<IEventType> EventTypes { get; }
+
+    public TEntity CreateNew()
+    {
+        if (_factory == null)
+        {
+            throw new InvalidOperationException(
+                "Cannot create new entity instance as no factory has been specified.");
+        }
+
+        return _factory();
+    }
+
+    public string GetId(TEntity aggregate)
+    {
+        if (aggregate == null) throw new ArgumentNullException(nameof(aggregate));
+
+        if (_idSelector == null)
+        {
+            throw new InvalidOperationException("Cannot get ID as no ID selector has been specified.");
+        }
+
+        return _idSelector(aggregate);
+    }
+
+    public string MakeStreamKey(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("ID cannot be null or whitespace", nameof(id));
+
+        return _idToStreamKeySelector(id);
+    }
+
+    public string MakeSnapshotKey(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id)) throw new ArgumentException("ID cannot be null or whitespace", nameof(id));
+
+        return _idToSnapshotKeySelector(id);
+    }
+
+    public string MakeSnapshotKey(TEntity aggregate)
+    {
+        return MakeSnapshotKey(GetId(aggregate));
+    }
+
+    public EventSourcedEntityTypeBase<TEntity> SetFactory(Func<TEntity> factory)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+        var clone = Clone();
+        clone._factory = factory;
+        return clone;
+    }
+
+    public EventSourcedEntityTypeBase<TEntity> SetIdSelector(Func<TEntity, string> idSelector)
+    {
+        if (idSelector == null) throw new ArgumentNullException(nameof(idSelector));
+
+        var clone = Clone();
+        clone._idSelector = idSelector;
+        return clone;
+    }
+
+    public EventSourcedEntityTypeBase<TEntity> SetKeyPrefix(string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+            throw new ArgumentException("Prefix cannot be null or whitespace.", nameof(prefix));
+
+        var clone = Clone();
+        clone._idToStreamKeySelector = GetIdToStreamKeySelector(prefix);
+        clone._idToSnapshotKeySelector = GetIdToSnapshotKeySelector(prefix);
+        return clone;
+    }
+
+    public EventSourcedEntityTypeBase<TEntity> SetIdToStreamKeySelector(
+        Func<string, string> idToStreamKeySelector)
+    {
+        if (idToStreamKeySelector == null) throw new ArgumentNullException(nameof(idToStreamKeySelector));
+
+        var clone = Clone();
+        clone._idToStreamKeySelector = idToStreamKeySelector;
+        return clone;
+    }
+
+    public EventSourcedEntityTypeBase<TEntity> SetIdToSnapshotKeySelector(
+        Func<string, string> idToSnapshotKeySelector)
+    {
+        if (idToSnapshotKeySelector == null) throw new ArgumentNullException(nameof(idToSnapshotKeySelector));
+
+        var clone = Clone();
+        clone._idToSnapshotKeySelector = idToSnapshotKeySelector;
+        return clone;
+    }
+
+    protected abstract EventSourcedEntityTypeBase<TEntity> Clone();
+
+    private static Func<TEntity> GetDefaultFactory()
+    {
+        var ctor = typeof(TEntity).GetConstructor(Type.EmptyTypes);
+        if (ctor == null)
+        {
+            return () => throw new InvalidOperationException(
+                "No factory function specified, and no default constructor found");
+        }
+
+        var newExpr = Expression.New(ctor);
+        var lambda = Expression.Lambda<Func<TEntity>>(newExpr);
+        return lambda.Compile();
+    }
+
+    private static Func<TEntity, string> GetDefaultIdSelector()
+    {
+        const string defaultIdPropertyName = "Id";
+
+        var idSelector =
+            (GetIdSelector(defaultIdPropertyName) ??
+             GetIdSelector($"{typeof(TEntity).Name}{defaultIdPropertyName}")) ??
+            (_ => throw new InvalidOperationException("No ID selector specified, and no suitable ID property found"));
+
+        return idSelector;
+    }
+
+    private static Func<TEntity, string>? GetIdSelector(string propertyName)
+    {
+        var property = typeof(TEntity).GetProperty(propertyName);
+        if (property == null)
+        {
+            return null;
+        }
+
+        var aggregateParam = Expression.Parameter(typeof(TEntity));
+        var propertyExpr = Expression.Property(aggregateParam, property);
+        var asString = Expression.Call(propertyExpr, nameof(ToString), null);
+        var lambda = Expression.Lambda<Func<TEntity, string>>(asString, aggregateParam);
+        return lambda.Compile();
+    }
+
+    private static string GetDefaultKeyPrefix()
+    {
+        var name = typeof(TEntity).Name;
+        return $"{name[..1].ToLower()}{name[1..]}";
+    }
+
+    private static Func<string, string> GetIdToStreamKeySelector(string prefix)
+    {
+        return id => $"{prefix}-{id}";
+    }
+
+    private static Func<string, string> GetIdToSnapshotKeySelector(string prefix)
+    {
+        return id => $"{prefix}Snapshot-{id}";
+    }
+}

--- a/src/DomainBlocks.Core/IAggregateType.cs
+++ b/src/DomainBlocks.Core/IAggregateType.cs
@@ -1,17 +1,11 @@
 namespace DomainBlocks.Core;
 
-public interface IAggregateType
+public interface IAggregateType : IEventSourcedEntityType
 {
-    Type ClrType { get; }
-    IEnumerable<IEventType> EventTypes { get; }
 }
 
-public interface IAggregateType<TAggregate> : IAggregateType
+public interface IAggregateType<TAggregate> : IAggregateType, IEventSourcedEntityType<TAggregate>
 {
-    TAggregate CreateNew();
-    string MakeStreamKey(string id);
-    string MakeSnapshotKey(string id);
-    string MakeSnapshotKey(TAggregate aggregate);
     ICommandExecutionContext<TAggregate> CreateCommandExecutionContext(TAggregate aggregate);
     TAggregate InvokeEventApplier(TAggregate aggregate, object @event);
 }

--- a/src/DomainBlocks.Core/IEventSourcedEntityType.cs
+++ b/src/DomainBlocks.Core/IEventSourcedEntityType.cs
@@ -1,0 +1,16 @@
+namespace DomainBlocks.Core;
+
+public interface IEventSourcedEntityType
+{
+    Type ClrType { get; }
+    IEnumerable<IEventType> EventTypes { get; }
+
+    string MakeStreamKey(string id);
+    string MakeSnapshotKey(string id);
+}
+
+public interface IEventSourcedEntityType<TEntity> : IEventSourcedEntityType
+{
+    TEntity CreateNew();
+    string MakeSnapshotKey(TEntity entity);
+}

--- a/src/DomainBlocks.Core/Model.cs
+++ b/src/DomainBlocks.Core/Model.cs
@@ -5,11 +5,11 @@ public sealed class Model
     private readonly IReadOnlyDictionary<Type, IAggregateType> _aggregateTypes;
     private readonly EventNameMap _eventNameMap;
 
-    public Model(IEnumerable<IAggregateType> aggregatesTypes)
+    public Model(IEnumerable<IAggregateType> aggregateTypes)
     {
-        if (aggregatesTypes == null) throw new ArgumentNullException(nameof(aggregatesTypes));
+        if (aggregateTypes == null) throw new ArgumentNullException(nameof(aggregateTypes));
 
-        _aggregateTypes = aggregatesTypes.ToDictionary(x => x.ClrType);
+        _aggregateTypes = aggregateTypes.ToDictionary(x => x.ClrType);
 
         // Build event name map from all aggregate types.
         var eventTypes = _aggregateTypes.Values.SelectMany(x => x.EventTypes);

--- a/tests/DomainBlocks.Core.Tests/ImmutableCommandExecutionContextTests.cs
+++ b/tests/DomainBlocks.Core.Tests/ImmutableCommandExecutionContextTests.cs
@@ -12,10 +12,10 @@ public class ImmutableCommandExecutionContextTests
     {
         var builder = new ImmutableAggregateTypeBuilder<ImmutableAggregate, IEvent>();
         builder.ApplyEventsWith((agg, e) => agg.Apply((dynamic)e));
-        var options = builder.AggregateType;
+        var aggregateType = builder.Build();
 
         var aggregate = new ImmutableAggregate();
-        var context = options.CreateCommandExecutionContext(aggregate);
+        var context = aggregateType.CreateCommandExecutionContext(aggregate);
 
         // Materialize the results. We expect the comment method to be called only once.
         var events = context.ExecuteCommand(x => x.MyCommandMethod("value")).ToList();
@@ -60,7 +60,7 @@ public class ImmutableCommandExecutionContextTests
             return new ImmutableAggregate(ObservedValues.Add(@event.Value));
         }
     }
-    
+
     private interface IEvent
     {
     }

--- a/tests/DomainBlocks.Core.Tests/MutableCommandExecutionContextTests.cs
+++ b/tests/DomainBlocks.Core.Tests/MutableCommandExecutionContextTests.cs
@@ -12,7 +12,7 @@ public class MutableCommandExecutionContextTests
         var builder = new MutableAggregateTypeBuilder<MutableAggregate, IEvent>();
         builder.WithEventEnumerableCommandResult().ApplyEvents(ApplyEventsBehavior.WhileEnumerating);
         builder.ApplyEventsWith((agg, e) => agg.Apply((dynamic)e));
-        var aggregateType = builder.AggregateType;
+        var aggregateType = builder.Build();
 
         var aggregate = new MutableAggregate();
         var context = aggregateType.CreateCommandExecutionContext(aggregate);
@@ -49,7 +49,7 @@ public class MutableCommandExecutionContextTests
             ObservedValues.Add(@event.Value);
         }
     }
-    
+
     private interface IEvent
     {
     }


### PR DESCRIPTION
Extract the concept of an `IEventSourcedEntityType` from the existing aggregate types. Also updates the supporting builder code.

The idea is to introduce an `IProcessType`, which represents an event sourced process. Much of the existing code we have around aggregates can be reused here, and this PR is a step towards this.