### PR TITLE
Add a position comparison for SqlStreamStore

### DIFF
--- a/src/DomainBlocks.Core/Subscriptions/EventStreamSubscription.cs
+++ b/src/DomainBlocks.Core/Subscriptions/EventStreamSubscription.cs
@@ -18,7 +18,7 @@ public sealed class EventStreamSubscription<TEvent, TPosition> :
     public EventStreamSubscription(
         IEventStream<TEvent, TPosition> eventStream,
         IEnumerable<IEventStreamConsumer<TEvent, TPosition>> consumers,
-        IComparer<TPosition?> positionComparer,
+        IComparer<TPosition?>? positionComparer = null,
         int queueSize = 1) :
         this(eventStream, consumers, new ArenaQueue<QueueNotification<TEvent, TPosition>>(queueSize), positionComparer)
     {
@@ -28,7 +28,7 @@ public sealed class EventStreamSubscription<TEvent, TPosition> :
         IEventStream<TEvent, TPosition> eventStream,
         IEnumerable<IEventStreamConsumer<TEvent, TPosition>> consumers,
         ArenaQueue<QueueNotification<TEvent, TPosition>> queue,
-        IComparer<TPosition?> positionComparer)
+        IComparer<TPosition?>? positionComparer = null)
     {
         _eventStream = eventStream;
 
@@ -37,7 +37,7 @@ public sealed class EventStreamSubscription<TEvent, TPosition> :
             .ToDictionary(x => x.Id);
 
         _queue = queue;
-        _positionComparer = positionComparer;
+        _positionComparer = positionComparer ?? Comparer<TPosition?>.Default;
     }
 
     public void Dispose()
@@ -82,8 +82,7 @@ public sealed class EventStreamSubscription<TEvent, TPosition> :
         return startPositions.Aggregate((acc, next) =>
         {
             var comparisonResult = _positionComparer.Compare(acc, next);
-            if (comparisonResult < 0) return acc;
-            return comparisonResult > 0 ? next : acc;
+            return comparisonResult <= 0 ? acc : next;
         });
     }
 

--- a/src/DomainBlocks.EventStore/Subscriptions/EventStoreSubscriptionBuilder.cs
+++ b/src/DomainBlocks.EventStore/Subscriptions/EventStoreSubscriptionBuilder.cs
@@ -31,7 +31,10 @@ public sealed class EventStoreSubscriptionBuilder
             var consumers = ((IEventStreamConsumerBuilderInfrastructure<ResolvedEvent, Position>)consumersBuilder)
                 .Build(eventAdapter);
 
-            return new EventStreamSubscription<ResolvedEvent, Position>(eventStream, consumers);
+            return new EventStreamSubscription<ResolvedEvent, Position>(
+                eventStream,
+                consumers,
+                Comparer<Position?>.Default);
         });
 
         return consumersBuilder;

--- a/src/DomainBlocks.EventStore/Subscriptions/EventStoreSubscriptionBuilder.cs
+++ b/src/DomainBlocks.EventStore/Subscriptions/EventStoreSubscriptionBuilder.cs
@@ -31,10 +31,7 @@ public sealed class EventStoreSubscriptionBuilder
             var consumers = ((IEventStreamConsumerBuilderInfrastructure<ResolvedEvent, Position>)consumersBuilder)
                 .Build(eventAdapter);
 
-            return new EventStreamSubscription<ResolvedEvent, Position>(
-                eventStream,
-                consumers,
-                Comparer<Position?>.Default);
+            return new EventStreamSubscription<ResolvedEvent, Position>(eventStream, consumers);
         });
 
         return consumersBuilder;

--- a/src/DomainBlocks.SqlStreamStore/Subscriptions/SqlStreamStorePositionComparer.cs
+++ b/src/DomainBlocks.SqlStreamStore/Subscriptions/SqlStreamStorePositionComparer.cs
@@ -1,0 +1,45 @@
+﻿using DomainBlocks.ThirdParty.SqlStreamStore.Streams;
+
+namespace DomainBlocks.SqlStreamStore.Subscriptions;
+
+public class SqlStreamStorePositionComparer : IComparer<long?>
+{
+    public int Compare(long? x, long? y)
+    {
+        // Compares two objects. An implementation of this method must return a
+        // value less than zero if x is less than y, zero if x is equal to y, or a
+        // value greater than zero if x is greater than y.
+        
+        
+        // X and Y == null -> They are equal
+        if (x == null && y == null)
+        {
+            return 0;
+        }
+        
+        // x == null --> x is less than y. 
+        if (x == null)
+        {
+            return -1;
+        }
+
+        // y == null --> y is less. 
+        if (y == null)
+        {
+            return 1;
+        }
+
+        if (x.Value == Position.End)
+        {
+            return 1;
+        }
+
+        if (y.Value == Position.End)
+        {
+            return -1;
+        }
+        
+        // values are not null, so compare them.
+        return x.Value.CompareTo(y.Value);
+    }
+}

--- a/src/DomainBlocks.SqlStreamStore/Subscriptions/SqlStreamStoreSubscriptionBuilder.cs
+++ b/src/DomainBlocks.SqlStreamStore/Subscriptions/SqlStreamStoreSubscriptionBuilder.cs
@@ -31,7 +31,10 @@ public class SqlStreamStoreSubscriptionBuilder
             var consumers = ((IEventStreamConsumerBuilderInfrastructure<StreamMessage, long>)consumersBuilder)
                 .Build(eventAdapter);
 
-            return new EventStreamSubscription<StreamMessage, long>(eventStream, consumers);
+            return new EventStreamSubscription<StreamMessage, long>(
+                eventStream,
+                consumers,
+                new SqlStreamStorePositionComparer());
         });
 
         return consumersBuilder;

--- a/tests/DomainBlocks.SqlStreamStore.Tests/PositionComparer/SqlStreamStorePositionComparerTests.cs
+++ b/tests/DomainBlocks.SqlStreamStore.Tests/PositionComparer/SqlStreamStorePositionComparerTests.cs
@@ -35,4 +35,20 @@ public class SqlStreamStorePositionComparerTests
         Assert.That(comparer.Compare(9999, 9999), Is.EqualTo(0));
         Assert.That(comparer.Compare(null, null), Is.EqualTo(0));
     }
+
+    [Test]
+    public void ArrayOfPositionsWithNulls_Returns_CorrectMinimumPosition()
+    {
+        var list = new long?[] {null, 1, 2, 3, 4, 5, -1};
+        var comparer = new SqlStreamStorePositionComparer();
+        
+        var result = list.Aggregate((acc, next) =>
+        {
+            var comparisonResult = comparer.Compare(acc, next);
+            if (comparisonResult < 0) return acc;
+            return comparisonResult > 0 ? next : acc;
+        });
+        
+        Assert.That(result, Is.EqualTo(null));
+    }
 }

--- a/tests/DomainBlocks.SqlStreamStore.Tests/PositionComparer/SqlStreamStorePositionComparerTests.cs
+++ b/tests/DomainBlocks.SqlStreamStore.Tests/PositionComparer/SqlStreamStorePositionComparerTests.cs
@@ -1,0 +1,38 @@
+﻿using DomainBlocks.SqlStreamStore.Subscriptions;
+using DomainBlocks.ThirdParty.SqlStreamStore.Streams;
+using NUnit.Framework;
+
+namespace DomainBlocks.SqlStreamStore.Tests.PositionComparer;
+
+[TestFixture]
+public class SqlStreamStorePositionComparerTests
+{
+    [Test]
+    public void PositionComparer_ConsidersNull_AsMinPosition()
+    {
+        var comparer = new SqlStreamStorePositionComparer();
+        Assert.That(comparer.Compare(null, 1), Is.EqualTo(-1));
+        Assert.That(comparer.Compare(null, 0), Is.EqualTo(-1));
+        Assert.That(comparer.Compare(1, null), Is.EqualTo(1));
+        Assert.That(comparer.Compare(0, null), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void PositionComparer_PositionEnd_IsLargestPosition()
+    {
+        var comparer = new SqlStreamStorePositionComparer();
+        Assert.That(comparer.Compare(Position.End, null), Is.EqualTo(1));
+        Assert.That(comparer.Compare(null, Position.End), Is.EqualTo(-1));
+        Assert.That(comparer.Compare(9999, Position.End), Is.EqualTo(-1));
+        Assert.That(comparer.Compare(Position.End, 9999), Is.EqualTo(1));
+    }
+    
+    [Test]
+    public void PositionComparer_Equality_ForValues()
+    {
+        var comparer = new SqlStreamStorePositionComparer();
+        Assert.That(comparer.Compare(1, 1), Is.EqualTo(0));
+        Assert.That(comparer.Compare(9999, 9999), Is.EqualTo(0));
+        Assert.That(comparer.Compare(null, null), Is.EqualTo(0));
+    }
+}


### PR DESCRIPTION
Inject the IComparer to the EventStreamSubscription. This will ensure we can properly handle new persisted / checkpointed projections that start from scratch.

Also handle -1 AKA the stream END as a greater position to the others.