### PR TITLE
refactor: simplify event loop

### DIFF
--- a/src/DomainBlocks.Core/Subscriptions/Concurrency/ArenaQueue.cs
+++ b/src/DomainBlocks.Core/Subscriptions/Concurrency/ArenaQueue.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 
@@ -16,11 +15,11 @@ internal class ArenaQueue<T> where T : class, new()
         _fullChannel = Channel.CreateBounded<int>(size);
         _arena = new T[size];
 
-        for (var i = 0; i < _arena.Length; i++)
+        // We initialise the empty channel queue with full capacity.
+        for (var i = 0; i < size; i++)
         {
             _arena[i] = new T();
-            var success = _emptyChannel.Writer.TryWrite(i);
-            Debug.Assert(success, "Failed writing index to empty channel");
+            _emptyChannel.Writer.TryWrite(i);
         }
     }
 


### PR DESCRIPTION
There should be no need to wrap the event loop in a Task.Run or Task.Factory.StartNew.

Also removed the Debug.Assert from the ArenaQueue constructor. There is no reason that writing to the empty channel here will fail.